### PR TITLE
Rename Simfony to SimplicityHL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,9 +571,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hex-conservative"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
 name = "hex-conservative"
@@ -934,9 +934,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniscript"
-version = "12.2.0"
+version = "12.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add2d4aee30e4291ce5cffa3a322e441ff4d4bc57b38c8d9bf0e94faa50ab626"
+checksum = "487906208f38448e186e3deb02f2b8ef046a9078b0de00bdb28bf4fb9b76951c"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1547,12 +1547,12 @@ dependencies = [
 [[package]]
 name = "simfony"
 version = "0.1.0"
-source = "git+https://github.com/uncomputable/simfony?rev=d5284014e9f67593e50b272f1f676ea8d09f6ec8#d5284014e9f67593e50b272f1f676ea8d09f6ec8"
+source = "git+https://github.com/BlockstreamResearch/simplicityhl?rev=d5284014e9f67593e50b272f1f676ea8d09f6ec8#d5284014e9f67593e50b272f1f676ea8d09f6ec8"
 dependencies = [
  "base64 0.21.7",
  "either",
  "getrandom",
- "hex-conservative 0.1.1",
+ "hex-conservative 0.1.2",
  "itertools 0.13.0",
  "miniscript",
  "pest",
@@ -1570,7 +1570,7 @@ dependencies = [
  "byteorder",
  "elements",
  "getrandom",
- "hex-conservative 0.1.1",
+ "hex-conservative 0.1.2",
  "miniscript",
  "santiago",
  "simplicity-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,18 @@ lib-profile-release = "wasm-release"
 
 [dependencies]
 itertools = "0.13.0"
-simfony = { git = "https://github.com/uncomputable/simfony", rev = "d5284014e9f67593e50b272f1f676ea8d09f6ec8" }
+#simplicityhl = "0.2.0"
+simplicityhl = { package = "simfony", git = "https://github.com/BlockstreamResearch/simplicityhl", rev = "d5284014e9f67593e50b272f1f676ea8d09f6ec8" }
 leptos = { version = "0.6.14", features = ["csr"] }
 leptos_router = { version = "0.6.15", features = ["csr"] }
 console_error_panic_hook = "0.1.7"
 hex-conservative = "0.2.1"
 js-sys = "0.3.70"
-web-sys = { version = "0.3.70", features = ["Navigator", "Clipboard", "Storage"] }
+web-sys = { version = "0.3.70", features = [
+    "Navigator",
+    "Clipboard",
+    "Storage",
+] }
 wasm-bindgen-futures = "0.4.43"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 gloo-net = "0.6.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# Stage 1: Builder
+# This stage installs all dependencies and builds the application.
+FROM debian:bookworm-slim AS builder
+
+# Install essential build tools, clang, and nodejs for sass
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    clang-16 \
+    llvm-16 \
+    curl \
+    pkg-config \
+    libssl-dev \
+    ca-certificates \
+    nodejs \
+    npm && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Rust and the wasm32 target
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
+    rustup target add wasm32-unknown-unknown
+
+# Install Trunk and Dart Sass
+RUN cargo install trunk && \
+    npm install -g sass
+
+# Set environment variables for the Wasm C compiler, mimicking the Nix setup.
+# This tells Rust's build scripts to use clang-16 when compiling C code for Wasm.
+ENV CC_wasm32_unknown_unknown=clang-16
+ENV AR_wasm32_unknown_unknown=llvm-ar-16
+ENV CFLAGS_wasm32_unknown_unknown="-I/usr/lib/clang/16/include"
+
+# Copy the application source code
+WORKDIR /app
+COPY . .
+
+# Build the application
+RUN trunk build --release && \
+    sh fix-links.sh
+
+# Stage 2: Final Image
+# This stage creates a minimal image to serve the built static files.
+FROM nginx:1.27-alpine-slim
+
+# Copy the built assets from the builder stage
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Expose port 80 and start Nginx
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,19 @@ Simfony looks and feels like [Rust](https://www.rust-lang.org). Just how Rust co
 
 ## Develop the project
 
-### Install dependencies
+### Using Docker
+
+Build
+```
+docker build -t simplicity-webide .
+```
+
+Run and naviate to `http://localhost:8080` in your web browser.
+```
+docker run -p 8080:80 simplicity-webide
+```
+
+### Using Nix
 
 First install nix.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Simfony Web IDE
+# SimplicityHL Web IDE
 
-[Simfony](https://github.com/BlockstreamResearch/simfony) is a high-level language for writing Bitcoin smart contracts.
+[SimplicityHL](https://github.com/BlockstreamResearch/simplicityhl) is a high-level language for writing Bitcoin smart contracts.
 
-Simfony looks and feels like [Rust](https://www.rust-lang.org). Just how Rust compiles down to assembly language, Simfony compiles down to Simplicity bytecode. Developers write Simfony, full nodes execute Simplicity.
+SimplicityHL looks and feels like [Rust](https://www.rust-lang.org). Just how Rust compiles down to assembly language, SimplicityHL compiles down to Simplicity bytecode. Developers write SimplicityHL, full nodes execute Simplicity.
 
-[A live demo is running on GitHub pages](https://simfony.dev).
+[A live demo is running](https://ide.simplicity-lang.org).
 
 ## Develop the project
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,16 +1,16 @@
 # How to make a transaction using the web IDE
 
-The Simfony web IDE can only make a restricted form of transaction: There is 1 transaction input, 1 transaction output and 1 fee output _(Liquid has explicit fee outputs)_. Confidential transactions or assets other than Bitcoin are not supported.
+The SimplicityHL web IDE can only make a restricted form of transaction: There is 1 transaction input, 1 transaction output and 1 fee output _(Liquid has explicit fee outputs)_. Confidential transactions or assets other than Bitcoin are not supported.
 
-![Screenshot of mempool.space](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/mempool1.png)
+![Screenshot of mempool.space](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/mempool1.png)
 
 ## Write the main function
 
-Open [the Simfony web IDE](https://simfony.dev/) and write the main function of your program.
+Open [the SimplicityHL web IDE](https://ide.simplicity-lang.org/) and write the main function of your program.
 
 _You can leave the default main function as it is. Customize it if you want._
 
-![Screenshot of the web IDE](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/webide0.png)
+![Screenshot of the web IDE](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/webide0.png)
 
 ## Generate an address
 
@@ -18,27 +18,27 @@ Click the "Address" button to copy the address of your program to the clipboard.
 
 Leave the web IDE tab open. You will need it later.
 
-![Screenshot of the web IDE](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/webide1.png)
+![Screenshot of the web IDE](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/webide1.png)
 
 ## Fund the address
 
 Paste the address into [the Liquid testnet faucet](https://liquidtestnet.com/faucet) and press the "Send assets" button.
 
-![Screenshot of the Liquid testnet faucet](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/faucet1.png)
+![Screenshot of the Liquid testnet faucet](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/faucet1.png)
 
 Copy the ID of the funding transaction to your clipboard.
 
-![Screenshot of the Liquid testnet faucet](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/faucet2.png)
+![Screenshot of the Liquid testnet faucet](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/faucet2.png)
 
 ## Look up the funding transaction
 
 Paste the ID of the funding transaction into the [Blockstream Explorer for Liquid testnet](https://blockstream.info/liquidtestnet/).
 
-![Screenshot of the Blockstream Explorer](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/esplora1.png)
+![Screenshot of the Blockstream Explorer](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/esplora1.png)
 
-Scroll down and find the Simfony UTXO. The Liquid testnet faucet always sends 100000 tL-BTC. In our example, the Simfony UTXO is vout = 1.
+Scroll down and find the SimplicityHL UTXO. The Liquid testnet faucet always sends 100000 tL-BTC. In our example, the SimplicityHL UTXO is vout = 1.
 
-![Screenshot of the Blockstream Explorer](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/esplora2.png)
+![Screenshot of the Blockstream Explorer](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/esplora2.png)
 
 ## Enter UTXO data into the web IDE
 
@@ -46,31 +46,31 @@ Enter the ID of the funding transaction and the vout into the web IDE.
 
 _You can leave the remaining fields as they are. Feel free to customize._
 
-![Screenshot of the Simfony web IDE](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/webide2.png)
+![Screenshot of the SimplicityHL web IDE](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/webide2.png)
 
 ## Sign the spending transaction
 
-Click the "Sig 0" button to generate a signature for a transaction that spends the Simfony UTXO.
+Click the "Sig 0" button to generate a signature for a transaction that spends the SimplicityHL UTXO.
 
-![Screenshot of the Simfony web IDE](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/webide3.png)
+![Screenshot of the SimplicityHL web IDE](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/webide3.png)
 
 Paste the signature into the `mod witness {...}` section.
 
-![Screenshot of the Simfony web IDE](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/webide4.png)
+![Screenshot of the SimplicityHL web IDE](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/webide4.png)
 
 ## Generate the spending transaction
 
 Click the "Transaction" button to copy the spending transaction to your clipboard.
 
-![Screenshot of the Simfony web IDE](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/webide5.png)
+![Screenshot of the SimplicityHL web IDE](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/webide5.png)
 
 ## Broadcast the spending transaction
 
 Paste the spending transaction into the [Blockstream Liquid testnet explorer](https://blockstream.info/liquidtestnet/tx/push) and click the "Broadcast transaction" button.
 
-![Screenshot of the Simfony web IDE](https://raw.githubusercontent.com/uncomputable/simfony-webide/master/doc/esplora3.png)
+![Screenshot of the SimplicityHL web IDE](https://raw.githubusercontent.com/BlockstreamResearch/simplicity-webide/master/doc/esplora3.png)
 
-If everything worked, the explorer will open the broadcast transaction. In this case, congratulations, you made a Simfony transaction on Liquid testnet!!! You can also look up your transaction on [mempool.space](https://liquid.network/testnet).
+If everything worked, the explorer will open the broadcast transaction. In this case, congratulations, you made a SimplicityHL transaction on Liquid testnet!!! You can also look up your transaction on [mempool.space](https://liquid.network/testnet).
 
 If you see an error message, take a look at the following "Troubleshooting" section.
 
@@ -126,7 +126,7 @@ The fee consumes the entire input value. Decrease the fee.
 
 A Simplicity jet fails.
 
-Double-check the conditions that your Simfony program enforces. Update the witness data or transaction parameters.
+Double-check the conditions that your SimplicityHL program enforces. Update the witness data or transaction parameters.
 
 Every time you change the transaction parameters, the signature hash of the transaction changes. In this case, you need to **regenerate signatures** using the "Key Store" tab.
 

--- a/src/components/footer.rs
+++ b/src/components/footer.rs
@@ -39,7 +39,7 @@ pub fn Footer() -> impl IntoView {
                         <a href="https://t.me/simplicity_community" class="footer-social-link">
                             <img src="images/telegram.svg" alt="Telegram Icon" class="footer-social-icon" />
                         </a>
-                        <a href="https://github.com/BlockstreamResearch/simfony" class="footer-social-link">
+                        <a href="https://github.com/BlockstreamResearch/simplicityhl" class="footer-social-link">
                             <img src="images/github.svg" alt="GitHub Icon" class="footer-social-icon" />
                         </a>
                     </div>

--- a/src/components/merkle.rs
+++ b/src/components/merkle.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use js_sys::{Array, Object};
 use leptos::*;
-use simfony::simplicity;
+use simplicityhl::simplicity;
 use simplicity::dag::DagLike;
 use simplicity::dag::NoSharing;
 use simplicity::node;

--- a/src/components/navigation.rs
+++ b/src/components/navigation.rs
@@ -58,7 +58,7 @@ pub fn Navigation() -> impl IntoView {
                                 <div class="navigation-dropdown-title">"Whitepaper"</div>
                                 <div class="navigation-dropdown-description">"The original Simplicity whitepaper, detailing the language."</div>
                             </a>
-                            <a href="https://docs.rs/simfony-as-rust" target="_blank" rel="noopener noreferrer" class="navigation-dropdown-item">
+                            <a href="https://docs.rs/simplicityhl-as-rust" target="_blank" rel="noopener noreferrer" class="navigation-dropdown-item">
                                 <div class="navigation-dropdown-title">"Jets Documentation"</div>
                                 <div class="navigation-dropdown-description">"Technical reference detailing each jet's functionality and use."</div>
                             </a>
@@ -140,7 +140,7 @@ pub fn Navigation() -> impl IntoView {
                         class:active=move || docs_open.get()
                     >
                         <a href="https://blockstream.com/simplicity.pdf" target="_blank" rel="noopener noreferrer" class="navigation-mobile-dropdown-item" on:click=close_mobile_menu>"Whitepaper"</a>
-                        <a href="https://docs.rs/simfony-as-rust" target="_blank" rel="noopener noreferrer" class="navigation-mobile-dropdown-item" on:click=close_mobile_menu>"Jets Documentation"</a>
+                        <a href="https://docs.rs/simplicityhl-as-rust" target="_blank" rel="noopener noreferrer" class="navigation-mobile-dropdown-item" on:click=close_mobile_menu>"Jets Documentation"</a>
                         <a href="https://docs.simplicity-lang.org/" target="_blank" rel="noopener noreferrer" class="navigation-mobile-dropdown-item" on:click=close_mobile_menu>"SimplicityHL"</a>
                         <a href="https://github.com/BlockstreamResearch/SimplicityHL/tree/master/examples" target="_blank" rel="noopener noreferrer" class="navigation-mobile-dropdown-item" on:click=close_mobile_menu>"Contract Examples"</a>
                     </div>

--- a/src/components/program_window/help_button.rs
+++ b/src/components/program_window/help_button.rs
@@ -3,7 +3,7 @@ use leptos::{component, view, IntoView};
 #[component]
 pub fn HelpButton() -> impl IntoView {
     view! {
-        <form action="https://github.com/uncomputable/simfony-webide/blob/master/doc/README.md" target="_blank">
+        <form action="https://github.com/BlockstreamResearch/simplicity-webide/blob/master/doc/README.md" target="_blank">
             <button class="button" type="submit">
                 " Help"
             </button>

--- a/src/components/program_window/program_tab.rs
+++ b/src/components/program_window/program_tab.rs
@@ -6,10 +6,10 @@ use leptos::{
     use_context, view, IntoView, RwSignal, Signal, SignalGetUntracked, SignalSet, SignalUpdate,
     SignalWith, SignalWithUntracked,
 };
-use simfony::parse::ParseFromStr;
-use simfony::simplicity::jet::elements::ElementsEnv;
-use simfony::{elements, simplicity};
-use simfony::{CompiledProgram, SatisfiedProgram, WitnessValues};
+use simplicityhl::parse::ParseFromStr;
+use simplicityhl::simplicity::jet::elements::ElementsEnv;
+use simplicityhl::{elements, simplicity};
+use simplicityhl::{CompiledProgram, SatisfiedProgram, WitnessValues};
 
 use crate::components::copy_to_clipboard::CopyToClipboard;
 use crate::function::Runner;
@@ -64,7 +64,7 @@ impl Program {
         }
         self.text.with_untracked(|text| {
             self.cached_text.set(text.clone());
-            let compiled = simfony::Arguments::parse_from_str(text)
+            let compiled = simplicityhl::Arguments::parse_from_str(text)
                 .map_err(|error| error.to_string())
                 .and_then(|args| CompiledProgram::new(text.as_str(), args));
             let cmr = compiled

--- a/src/components/program_window/transaction_button.rs
+++ b/src/components/program_window/transaction_button.rs
@@ -1,7 +1,7 @@
 use elements::pset::serialize::Serialize;
 use hex_conservative::DisplayHex;
 use leptos::{component, use_context, view, with, IntoView};
-use simfony::elements;
+use simplicityhl::elements;
 
 use crate::components::copy_to_clipboard::CopyToClipboard;
 use crate::components::program_window::Program;

--- a/src/components/run_window/hash_store_tab.rs
+++ b/src/components/run_window/hash_store_tab.rs
@@ -4,7 +4,7 @@ use leptos::{
     component, create_rw_signal, use_context, view, For, IntoView, RwSignal, SignalGet,
     SignalUpdate, View,
 };
-use simfony::elements::hashes;
+use simplicityhl::elements::hashes;
 
 use crate::components::copy_to_clipboard::CopyToClipboard;
 use crate::util::{Counter26, HashedData};

--- a/src/components/run_window/key_store_tab.rs
+++ b/src/components/run_window/key_store_tab.rs
@@ -8,7 +8,7 @@ use leptos::{
     IntoView, NodeRef, RwSignal, Signal, SignalGet, SignalGetUntracked, SignalSet, SignalUpdate,
     SignalWith, View,
 };
-use simfony::{elements, simplicity};
+use simplicityhl::{elements, simplicity};
 
 use crate::components::copy_to_clipboard::CopyToClipboard;
 use crate::util::{Counter26, SigningKeys};

--- a/src/components/run_window/transaction_tab.rs
+++ b/src/components/run_window/transaction_tab.rs
@@ -5,8 +5,8 @@ use leptos::{
     component, create_rw_signal, ev, event_target_value, use_context, view, with, Children,
     IntoView, RwSignal, Signal, SignalGetUntracked, SignalSet, SignalUpdate,
 };
-use simfony::{elements, simplicity};
 use simplicity::jet::elements::ElementsEnv;
+use simplicityhl::{elements, simplicity};
 
 use crate::components::program_window::Program;
 use crate::components::string_box::ErrorBox;

--- a/src/components/state.rs
+++ b/src/components/state.rs
@@ -1,5 +1,5 @@
 use leptos::{use_context, SignalGetUntracked, SignalWithUntracked};
-use simfony::num::U256;
+use simplicityhl::num::U256;
 use web_sys::window;
 
 use crate::components::program_window::Program;

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -3,21 +3,21 @@ use std::collections::HashMap;
 use crate::transaction::TxParams;
 use elements::hashes::{sha256, Hash};
 use elements::secp256k1_zkp as secp256k1;
-use simfony::elements::hashes::HashEngine;
-use simfony::num::U256;
-use simfony::simplicity::Preimage32;
-use simfony::str::WitnessName;
-use simfony::types::TypeConstructible;
-use simfony::value::ValueConstructible;
-use simfony::{elements, ResolvedType, Value};
+use simplicityhl::elements::hashes::HashEngine;
+use simplicityhl::num::U256;
+use simplicityhl::simplicity::Preimage32;
+use simplicityhl::str::WitnessName;
+use simplicityhl::types::TypeConstructible;
+use simplicityhl::value::ValueConstructible;
+use simplicityhl::{elements, ResolvedType, Value};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Example {
     description: &'static str,
     program: &'static str,
-    compute_args: fn(&[secp256k1::XOnlyPublicKey], &[sha256::Hash]) -> simfony::Arguments,
+    compute_args: fn(&[secp256k1::XOnlyPublicKey], &[sha256::Hash]) -> simplicityhl::Arguments,
     compute_witness:
-        fn(&[secp256k1::Keypair], &[Preimage32], secp256k1::Message) -> simfony::WitnessValues,
+        fn(&[secp256k1::Keypair], &[Preimage32], secp256k1::Message) -> simplicityhl::WitnessValues,
     lock_time: u32,
     sequence: u32,
 }
@@ -36,7 +36,7 @@ impl Example {
         self,
         public_keys: &[secp256k1::XOnlyPublicKey],
         hashes: &[sha256::Hash],
-    ) -> simfony::Arguments {
+    ) -> simplicityhl::Arguments {
         (self.compute_args)(public_keys, hashes)
     }
 
@@ -45,7 +45,7 @@ impl Example {
         secret_keys: &[secp256k1::Keypair],
         preimages: &[Preimage32],
         sighash_all: secp256k1::Message,
-    ) -> simfony::WitnessValues {
+    ) -> simplicityhl::WitnessValues {
         (self.compute_witness)(secret_keys, preimages, sighash_all)
     }
 
@@ -65,8 +65,8 @@ impl Example {
 fn p2pk_args(
     public_keys: &[secp256k1::XOnlyPublicKey],
     _hashes: &[sha256::Hash],
-) -> simfony::Arguments {
-    simfony::Arguments::from(HashMap::from([(
+) -> simplicityhl::Arguments {
+    simplicityhl::Arguments::from(HashMap::from([(
         WitnessName::from_str_unchecked("ALICE_PUBLIC_KEY"),
         Value::u256(U256::from_byte_array(public_keys[0].serialize())),
     )]))
@@ -76,8 +76,8 @@ fn p2pk_witness(
     secret_keys: &[secp256k1::Keypair],
     _preimages: &[Preimage32],
     sighash_all: secp256k1::Message,
-) -> simfony::WitnessValues {
-    simfony::WitnessValues::from(HashMap::from([(
+) -> simplicityhl::WitnessValues {
+    simplicityhl::WitnessValues::from(HashMap::from([(
         WitnessName::from_str_unchecked("ALICE_SIGNATURE"),
         Value::byte_array(secret_keys[0].sign_schnorr(sighash_all).serialize()),
     )]))
@@ -99,9 +99,9 @@ The coins move if the person with the given public key signs the transaction."#,
 fn p2pkh_args(
     public_keys: &[secp256k1::XOnlyPublicKey],
     _hashes: &[sha256::Hash],
-) -> simfony::Arguments {
+) -> simplicityhl::Arguments {
     let pk_hash = sha256::Hash::hash(&public_keys[0].serialize());
-    simfony::Arguments::from(HashMap::from([(
+    simplicityhl::Arguments::from(HashMap::from([(
         WitnessName::from_str_unchecked("ALICE_PUBLIC_KEY_HASH"),
         Value::u256(U256::from_byte_array(pk_hash.to_byte_array())),
     )]))
@@ -111,9 +111,9 @@ fn p2pkh_witness(
     secret_keys: &[secp256k1::Keypair],
     _preimages: &[Preimage32],
     sighash_all: secp256k1::Message,
-) -> simfony::WitnessValues {
+) -> simplicityhl::WitnessValues {
     let alice_pk = secret_keys[0].x_only_public_key().0;
-    simfony::WitnessValues::from(HashMap::from([
+    simplicityhl::WitnessValues::from(HashMap::from([
         (
             WitnessName::from_str_unchecked("ALICE_PUBLIC_KEY"),
             Value::u256(U256::from_byte_array(alice_pk.serialize())),
@@ -153,8 +153,8 @@ fn main() {
 fn p2ms_args(
     public_keys: &[secp256k1::XOnlyPublicKey],
     _hashes: &[sha256::Hash],
-) -> simfony::Arguments {
-    simfony::Arguments::from(HashMap::from([
+) -> simplicityhl::Arguments {
+    simplicityhl::Arguments::from(HashMap::from([
         (
             WitnessName::from_str_unchecked("ALICE_PUBLIC_KEY"),
             Value::u256(U256::from_byte_array(public_keys[0].serialize())),
@@ -174,7 +174,7 @@ fn p2ms_witness(
     secret_keys: &[secp256k1::Keypair],
     _preimages: &[Preimage32],
     sighash_all: secp256k1::Message,
-) -> simfony::WitnessValues {
+) -> simplicityhl::WitnessValues {
     let alice_sig = Value::some(Value::byte_array(
         secret_keys[0].sign_schnorr(sighash_all).serialize(),
     ));
@@ -184,7 +184,7 @@ fn p2ms_witness(
     ));
     let ty = alice_sig.ty().clone();
     let signatures = Value::array([alice_sig, bob_sig, charlie_sig], ty);
-    simfony::WitnessValues::from(HashMap::from([(
+    simplicityhl::WitnessValues::from(HashMap::from([(
         WitnessName::from_str_unchecked("SIGNATURES_2_OF_3"),
         signatures,
     )]))
@@ -285,8 +285,8 @@ fn main() {
 fn htlc_args(
     public_keys: &[secp256k1::XOnlyPublicKey],
     hashes: &[sha256::Hash],
-) -> simfony::Arguments {
-    simfony::Arguments::from(HashMap::from([
+) -> simplicityhl::Arguments {
+    simplicityhl::Arguments::from(HashMap::from([
         (
             WitnessName::from_str_unchecked("ALICE_PUBLIC_KEY"),
             Value::u256(U256::from_byte_array(public_keys[0].serialize())),
@@ -306,7 +306,7 @@ fn htlc_witness(
     secret_keys: &[secp256k1::Keypair],
     preimages: &[Preimage32],
     sighash_all: secp256k1::Message,
-) -> simfony::WitnessValues {
+) -> simplicityhl::WitnessValues {
     let alice_sig = secret_keys[0].sign_schnorr(sighash_all);
     let complete_or_cancel = Value::left(
         Value::product(
@@ -315,7 +315,7 @@ fn htlc_witness(
         ),
         ResolvedType::byte_array(64),
     );
-    simfony::WitnessValues::from(HashMap::from([(
+    simplicityhl::WitnessValues::from(HashMap::from([(
         WitnessName::from_str_unchecked("COMPLETE_OR_CANCEL"),
         complete_or_cancel,
     )]))
@@ -371,8 +371,8 @@ fn main() {
 fn hodl_vault_args(
     public_keys: &[secp256k1::XOnlyPublicKey],
     _hashes: &[sha256::Hash],
-) -> simfony::Arguments {
-    simfony::Arguments::from(HashMap::from([
+) -> simplicityhl::Arguments {
+    simplicityhl::Arguments::from(HashMap::from([
         (
             WitnessName::from_str_unchecked("MIN_HEIGHT"),
             Value::u32(1000),
@@ -396,7 +396,7 @@ fn hodl_vault_witness(
     secret_keys: &[secp256k1::Keypair],
     _preimages: &[Preimage32],
     sighash_all: secp256k1::Message,
-) -> simfony::WitnessValues {
+) -> simplicityhl::WitnessValues {
     let mut witness_values = HashMap::new();
     let oracle_height = 1000;
     witness_values.insert(
@@ -421,7 +421,7 @@ fn hodl_vault_witness(
         WitnessName::from_str_unchecked("BOB_SIGNATURE"),
         Value::byte_array(secret_keys[1].sign_schnorr(sighash_all).serialize()),
     );
-    simfony::WitnessValues::from(witness_values)
+    simplicityhl::WitnessValues::from(witness_values)
 }
 
 const HOLD_VAULT: Example = Example {
@@ -470,8 +470,8 @@ fn main() {
 fn last_will_args(
     public_keys: &[secp256k1::XOnlyPublicKey],
     _hashes: &[sha256::Hash],
-) -> simfony::Arguments {
-    simfony::Arguments::from(HashMap::from([
+) -> simplicityhl::Arguments {
+    simplicityhl::Arguments::from(HashMap::from([
         (
             WitnessName::from_str_unchecked("ALICE_PUBLIC_KEY"),
             Value::u256(U256::from_byte_array(public_keys[0].serialize())),
@@ -491,13 +491,13 @@ fn last_will_witness(
     secret_keys: &[secp256k1::Keypair],
     _preimages: &[Preimage32],
     sighash_all: secp256k1::Message,
-) -> simfony::WitnessValues {
+) -> simplicityhl::WitnessValues {
     let alice_sig = Value::byte_array(secret_keys[0].sign_schnorr(sighash_all).serialize());
     let inherit_or_not = Value::left(
         alice_sig,
         ResolvedType::either(ResolvedType::byte_array(64), ResolvedType::byte_array(64)),
     );
-    simfony::WitnessValues::from(HashMap::from([(
+    simplicityhl::WitnessValues::from(HashMap::from([(
         WitnessName::from_str_unchecked("INHERIT_OR_NOT"),
         inherit_or_not,
     )]))
@@ -560,16 +560,16 @@ fn main() {
 fn empty_args(
     _public_keys: &[secp256k1::XOnlyPublicKey],
     _hashes: &[sha256::Hash],
-) -> simfony::Arguments {
-    simfony::Arguments::default()
+) -> simplicityhl::Arguments {
+    simplicityhl::Arguments::default()
 }
 
 fn empty_witness(
     _secret_keys: &[secp256k1::Keypair],
     _preimages: &[Preimage32],
     _sighash_all: secp256k1::Message,
-) -> simfony::WitnessValues {
-    simfony::WitnessValues::default()
+) -> simplicityhl::WitnessValues {
+    simplicityhl::WitnessValues::default()
 }
 
 const HASH_LOOP: Example = Example {

--- a/src/jet.rs
+++ b/src/jet.rs
@@ -1,4 +1,3 @@
-use simfony::simplicity;
 use simplicity::ffi::c_jets::frame_ffi::{c_readBit, c_writeBit};
 use simplicity::ffi::c_jets::uword_width;
 use simplicity::ffi::ffi::UWORD;
@@ -6,6 +5,7 @@ use simplicity::ffi::CFrameItem;
 use simplicity::jet::Jet;
 use simplicity::types::Final;
 use simplicity::Value;
+use simplicityhl::simplicity;
 
 pub struct JetFailed;
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use elements::confidential;
 use elements::hashes::Hash;
-use simfony::simplicity::jet::Elements;
-use simfony::simplicity::RedeemNode;
-use simfony::{elements, simplicity};
 use simplicity::jet::elements::{ElementsEnv, ElementsUtxo};
+use simplicityhl::simplicity::jet::Elements;
+use simplicityhl::simplicity::RedeemNode;
+use simplicityhl::{elements, simplicity};
 
 use crate::util;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,13 +3,13 @@ use std::fmt;
 use elements::hashes::{sha256, Hash};
 use elements::secp256k1_zkp as secp256k1;
 use secp256k1::rand::{self, Rng, SeedableRng};
-use simfony::num::U256;
-use simfony::simplicity::Preimage32;
-use simfony::{elements, simplicity};
 use simplicity::dag::{DagLike, MaxSharing, NoSharing};
 use simplicity::jet::Elements;
 use simplicity::node::Inner;
 use simplicity::{node, RedeemNode};
+use simplicityhl::num::U256;
+use simplicityhl::simplicity::Preimage32;
+use simplicityhl::{elements, simplicity};
 
 #[derive(Clone, Debug)]
 pub struct SigningKeys {


### PR DESCRIPTION
it appears the latest version of SimplicityHL has some breaking changes and the IDE doesn't build against it. I've left the original reference there, but against the BlockstreamResearch repo and against the last working commit. 

```
[dependencies]
#simplicityhl = "0.2.0"
simplicityhl = { package = "simfony", git = "https://github.com/BlockstreamResearch/simplicityhl", rev = "d5284014e9f67593e50b272f1f676ea8d09f6ec8" }
```

